### PR TITLE
Added persistent_queue capability to Azure Monitor Exporter

### DIFF
--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -27,6 +27,11 @@ The following settings can be optionally configured:
 - `maxbatchsize` (default = 1024): The maximum number of telemetry items that can be submitted in each request. If this many items are buffered, the buffer will be flushed before `maxbatchinterval` expires.
 - `maxbatchinterval` (default = 10s): The maximum time to wait before sending a batch of telemetry.
 - `spaneventsenabled` (default = false): Enables export of span events.
+- `sending_queue`
+  - `enabled` (default = false)
+  - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
+  - `queue_size` (default = 1000): Maximum number of batches kept in memory before data; ignored if `enabled` is `false`
+  - `storage` (default = `none`): When set, enables persistence and uses the component specified as a storage extension for the persistent queue
 
 Example:
 

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -7,13 +7,15 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 // Config defines configuration for Azure Monitor
 type Config struct {
-	Endpoint           string              `mapstructure:"endpoint"`
-	InstrumentationKey configopaque.String `mapstructure:"instrumentation_key"`
-	MaxBatchSize       int                 `mapstructure:"maxbatchsize"`
-	MaxBatchInterval   time.Duration       `mapstructure:"maxbatchinterval"`
-	SpanEventsEnabled  bool                `mapstructure:"spaneventsenabled"`
+	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
+	Endpoint                     string              `mapstructure:"endpoint"`
+	InstrumentationKey           configopaque.String `mapstructure:"instrumentation_key"`
+	MaxBatchSize                 int                 `mapstructure:"maxbatchsize"`
+	MaxBatchInterval             time.Duration       `mapstructure:"maxbatchinterval"`
+	SpanEventsEnabled            bool                `mapstructure:"spaneventsenabled"`
 }

--- a/exporter/azuremonitorexporter/logexporter.go
+++ b/exporter/azuremonitorexporter/logexporter.go
@@ -47,5 +47,11 @@ func newLogsExporter(config *Config, transportChannel transportChannel, set expo
 		logger:           set.Logger,
 	}
 
-	return exporterhelper.NewLogsExporter(context.TODO(), set, config, exporter.onLogData)
+	return exporterhelper.NewLogsExporter(
+		context.TODO(),
+		set,
+		config,
+		exporter.onLogData,
+		exporterhelper.WithQueue(config.QueueSettings),
+	)
 }

--- a/exporter/azuremonitorexporter/metricexporter.go
+++ b/exporter/azuremonitorexporter/metricexporter.go
@@ -49,5 +49,10 @@ func newMetricsExporter(config *Config, transportChannel transportChannel, set e
 		packer:           newMetricPacker(set.Logger),
 	}
 
-	return exporterhelper.NewMetricsExporter(context.TODO(), set, config, exporter.onMetricData)
+	return exporterhelper.NewMetricsExporter(
+		context.TODO(),
+		set,
+		config,
+		exporter.onMetricData,
+		exporterhelper.WithQueue(config.QueueSettings))
 }

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -70,5 +70,10 @@ func newTracesExporter(config *Config, transportChannel transportChannel, set ex
 		logger:           set.Logger,
 	}
 
-	return exporterhelper.NewTracesExporter(context.TODO(), set, config, exporter.onTraceData)
+	return exporterhelper.NewTracesExporter(
+		context.TODO(),
+		set,
+		config,
+		exporter.onTraceData,
+		exporterhelper.WithQueue(config.QueueSettings))
 }


### PR DESCRIPTION
**Description:** 
Added a new config item to support the QueueSettings values.
Extended the exportHelper.New[Metrics|Logs|Traces]Exporter call to pass in the QueueSettings config, thus enabling persistent_queue for this exporter.

**Link to tracking Issue:** 
Fixes issue #25859

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:**
Added sending_queue config items to README.md's configuration section.